### PR TITLE
Migrate ubuntu 16 to ubuntu18 as ubuntu 16 is deprecated.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, macos-10.15, windows-2016]
+        os: [ubuntu-18.04, macos-10.15, windows-2016]
         javaToBuild: [jdk11u, jdk16u]
     steps:
     - uses: actions/checkout@v1
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, macos-10.15]
+        os: [ubuntu-18.04, macos-10.15]
         javaToBuild: [jdk11u, jdk16u]
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, macos-10.15, windows-2016]
+        os: [ubuntu-18.04, macos-10.15, windows-2016]
         javaToBuild: [jdk11u, jdk16u]
     steps:
     - uses: actions/checkout@v1
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, macos-10.15]
+        os: [ubuntu-18.04, macos-10.15]
         javaToBuild: [jdk11u, jdk16u]
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>