### PR TITLE
Remove dtrace from all linux builds as it doesn't work

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -44,8 +44,12 @@ export async function buildJDK(
   //pre-install dependencies
   await installDependencies(javaToBuild, impl)
   let jdkBootDir = ''
-  const bootJDKVersion = getBootJdkVersion(javaToBuild)
-  
+
+  let bootJDKVersion = getBootJdkVersion(javaToBuild)
+  if (parseInt(bootJDKVersion) == 10) {
+    bootJDKVersion = '11'
+  }
+
   if (`JAVA_HOME_${bootJDKVersion}_X64` in process.env) {
     jdkBootDir = process.env[`JAVA_HOME_${bootJDKVersion}_X64`] as string
     if (IS_WINDOWS) {
@@ -80,11 +84,15 @@ export async function buildJDK(
     }
 
     // If current JDK version is greater than (or equal to) 15, "auto" is no longer a valid value for the enable-dtrace config parameter.
-    if ((parseInt(getBootJdkVersion(javaToBuild)) + 1) >= 15) {
-      configureArgs = configureArgs + ' --enable-dtrace'
-    } else {
-      configureArgs = configureArgs + ' --enable-dtrace=auto'
-    }
+    // TODO: Figure out why the sdt.h file can't be found by AC_CHECK_HEADERS in jvm-features.m4,
+    //       but only during a git action. Apt-getting systemtap-sdt-dev definitely puts sdt.h
+    //       on the machine, and a sandbox addition of AC_CHECK_FILE confirms this.
+    //       Dtrace cannot be successfully enabled in any build until this is resolved.
+    // if ((parseInt(getBootJdkVersion(javaToBuild)) + 1) >= 15) {
+    //   configureArgs = configureArgs + ' --enable-dtrace'
+    // } else {
+    //   configureArgs = configureArgs + ' --enable-dtrace=auto'
+    // }
   } else {
     if (`${impl}` === 'hotspot') {
       configureArgs = "--disable-ccache --disable-warnings-as-errors"


### PR DESCRIPTION
On JDK15 and up, attempting (and failing) to enable dtrace will
cause the build to fail during the configure step, so I'm excluding
the dtrace enabling code for now.

On JDK14 and below, attempting (and failing) to enable dtrace will
not cause the build to fail, but the error message isn't obvious
unless you read the entire configure output, so I'm excluding it
there for consistency.

Full details on "why" dtrace cannot be enabled in a github actions
build has been added into the code as a todo comment. This can be
resolved if and when it reaches the top of someone's priority stack.

Signed-off-by: Adam Farley <adfarley@redhat.com>